### PR TITLE
SF: Bring back support for disabling backpressure propagation

### DIFF
--- a/services/surfaceflinger/Scheduler/include/scheduler/Features.h
+++ b/services/surfaceflinger/Scheduler/include/scheduler/Features.h
@@ -30,6 +30,7 @@ enum class Feature : std::uint8_t {
     kBackpressureGpuComposition = 1 << 4,
     kSmallDirtyContentDetection = 1 << 5,
     kExpectedPresentTime = 1 << 6,
+    kPropagateBackpressure = 1 << 7,
 };
 
 using FeatureFlags = ftl::Flags<Feature>;

--- a/services/surfaceflinger/Scheduler/include/scheduler/FrameTargeter.h
+++ b/services/surfaceflinger/Scheduler/include/scheduler/FrameTargeter.h
@@ -115,7 +115,8 @@ public:
     FrameTargeter(PhysicalDisplayId displayId, FeatureFlags flags)
           : FrameTarget(to_string(displayId)),
             mBackpressureGpuComposition(flags.test(Feature::kBackpressureGpuComposition)),
-            mSupportsExpectedPresentTime(flags.test(Feature::kExpectedPresentTime)) {}
+            mSupportsExpectedPresentTime(flags.test(Feature::kExpectedPresentTime)),
+            mPropagateBackpressure(flags.test(Feature::kPropagateBackpressure)) {}
 
     const FrameTarget& target() const { return *this; }
 
@@ -151,6 +152,7 @@ private:
 
     const bool mBackpressureGpuComposition;
     const bool mSupportsExpectedPresentTime;
+    const bool mPropagateBackpressure;
 
     TimePoint mScheduledPresentTime;
     CompositionCoverageFlags mCompositionCoverage;

--- a/services/surfaceflinger/Scheduler/src/FrameTargeter.cpp
+++ b/services/surfaceflinger/Scheduler/src/FrameTargeter.cpp
@@ -97,7 +97,7 @@ void FrameTargeter::beginFrame(const BeginFrameArgs& args, const IVsyncSource& v
     //
     // TODO(b/280667110): The grace period should depend on `sfWorkDuration` and `vsyncPeriod` being
     // approximately equal, not whether backpressure propagation is enabled.
-    const int graceTimeForPresentFenceMs = static_cast<int>(
+    const int graceTimeForPresentFenceMs = mPropagateBackpressure && static_cast<int>(
             mBackpressureGpuComposition || !mCompositionCoverage.test(CompositionCoverage::Gpu));
 
     // Pending frames may trigger backpressure propagation.

--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -486,6 +486,10 @@ SurfaceFlinger::SurfaceFlinger(Factory& factory) : SurfaceFlinger(factory, SkipI
 
     mDebugFlashDelay = base::GetUintProperty("debug.sf.showupdates"s, 0u);
 
+    property_get("debug.sf.disable_backpressure", value, "0");
+    mPropagateBackpressure = !atoi(value);
+    ALOGI_IF(!mPropagateBackpressure, "Disabling backpressure propagation");
+
     mBackpressureGpuComposition = base::GetBoolProperty("debug.sf.enable_gl_backpressure"s, true);
     ALOGI_IF(mBackpressureGpuComposition, "Enabling backpressure for GPU composition");
 
@@ -2558,7 +2562,7 @@ bool SurfaceFlinger::commit(PhysicalDisplayId pacesetterId,
     }
 
     if (pacesetterFrameTarget.isFramePending()) {
-        if (mBackpressureGpuComposition || pacesetterFrameTarget.didMissHwcFrame()) {
+        if (mPropagateBackpressure && (mBackpressureGpuComposition || pacesetterFrameTarget.didMissHwcFrame())) {
             if (FlagManager::getInstance().vrr_config()) {
                 mScheduler->getVsyncSchedule()->getTracker().onFrameMissed(
                         pacesetterFrameTarget.expectedPresentTime());
@@ -4395,6 +4399,9 @@ void SurfaceFlinger::initScheduler(const sp<const DisplayDevice>& display) {
     }
     if (mBackpressureGpuComposition) {
         features |= Feature::kBackpressureGpuComposition;
+    }
+    if (mPropagateBackpressure) {
+        features |= Feature::kPropagateBackpressure;
     }
     if (getHwComposer().getComposer()->isSupported(
                 Hwc2::Composer::OptionalFeature::ExpectedPresentTime)) {

--- a/services/surfaceflinger/SurfaceFlinger.h
+++ b/services/surfaceflinger/SurfaceFlinger.h
@@ -1300,6 +1300,7 @@ private:
     std::atomic_bool mForceFullDamage = false;
 
     bool mLayerCachingEnabled = false;
+    bool mPropagateBackpressure = true;
     bool mBackpressureGpuComposition = false;
 
     LayerTracing mLayerTracing;


### PR DESCRIPTION
[Pulkit077]: Adapt to A14 QPR1
[SamarV-121]: Adapt to A14 QPR3

Taken from CLO (QSSI 13). Some Qualcomm devices can still benefit from disabling backpressure propagation by setting:

debug.sf.disable_backpressure=1

Change-Id: I669a6059a2a971aa79603e74153fa93729f703dc